### PR TITLE
Add rule to avoid alias functions

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -75,6 +75,7 @@ final class Config extends PhpCsFixerConfig
             'no_empty_comment' => true,
             'no_empty_phpdoc' => true,
             'declare_strict_types' => true,
+            'no_alias_functions' => true,
         ];
     }
 }


### PR DESCRIPTION
### Added
- Added rule `no_alias_functions` to avoid alias functions

---

Ticket: https://jira.publiq.be/browse/III-6150